### PR TITLE
feat: support preinstall npm-script

### DIFF
--- a/fixtures/node_modules/bar/package.json
+++ b/fixtures/node_modules/bar/package.json
@@ -1,7 +1,13 @@
 {
   "name": "bar",
   "scripts": {
+    "start": "webpack",
+    "preinstall": "node bar-preinstall",
     "install": "node bar-install",
-    "postinstall": "node bar-postinstall"
+    "postinstall": "node bar-postinstall",
+    "prepublish": "node bar-prepublish",
+    "preprepare": "node bar-preprepare",
+    "prepare": "node bar-prepare",
+    "postprepare": "node bar-postprepare"
   }
 }

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = async target => {
     const json = require(path.resolve(packageJson));
     const packageName = json.name;
     if (json.scripts) {
-      ['install', 'postinstall'].forEach(script => {
+      ['preinstall', 'install', 'postinstall'].forEach(script => {
         if (json.scripts[script]) {
           let result = fileMap[packageName] || {
             name: packageName,

--- a/test.js
+++ b/test.js
@@ -10,6 +10,7 @@ const installScripts = require("./");
       "bar": {
         name: "bar",
         scripts: {
+          preinstall: "node bar-preinstall",
           install: "node bar-install",
           postinstall: "node bar-postinstall"
         },


### PR DESCRIPTION
`preinstall` scripts are executed during `npm install` and `npm ci` as the same with `install` and `postinstall`.